### PR TITLE
tests: Find cred_store.pickle no matter the current directory

### DIFF
--- a/tests/coap_client.py
+++ b/tests/coap_client.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import pickle
 from binascii import unhexlify
+from pathlib import Path
 
 import cbor2
 from aiocoap import Context, Message
@@ -33,7 +34,7 @@ cert = unhexlify(cert)
 
 cred_id = cbor2.loads(unhexlify(b"a11822822e485b786988439ebcf2"))
 
-with open("cred_store.pickle", 'rb') as h:
+with (Path(__file__).parent / "cred_store.pickle").open('rb') as h:
     credentials_storage = pickle.load(h)
 
 

--- a/tests/coap_server.py
+++ b/tests/coap_server.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import pickle
 from binascii import unhexlify
+from pathlib import Path
 
 import aiocoap
 import aiocoap.resource as resource
@@ -36,7 +37,7 @@ cred_id = cbor2.loads(unhexlify(b"a11822822e48fc79990f2431a3f5"))
 
 
 class EdhocResponder(resource.Resource):
-    cred_store = "cred_store.pickle"
+    cred_store = Path(__file__).parent / "cred_store.pickle"
 
     def __init__(self, cred_idr, cred, auth_key):
         super().__init__()


### PR DESCRIPTION
When running the tests from any other location than the local directory (I first tried them as `python3 tests/coap_client.py localhost`), they fail to find their pickle jar.

This patch changes their lookup behavior to not use the current working directory, but to look next to their own program code.

If it's the intention of the current expression to make it usable with any directory where there is a `cred_store.pickle`, I can adjust it to give an error message or fall back, but my impression is that it was simply always used locally so far.