### PR TITLE
Small fixes from the IETF110 hackathon

### DIFF
--- a/edhoc/exceptions.py
+++ b/edhoc/exceptions.py
@@ -1,3 +1,6 @@
 class EdhocException(Exception):
     """ Exception related to the configuration of the selected and supported ciphers. """
     pass
+
+class EdhocInvalidMessage(EdhocException):
+    """Decoding was attempted assuming a particular message shape that was not provided"""

--- a/edhoc/messages/error.py
+++ b/edhoc/messages/error.py
@@ -16,5 +16,13 @@ class MessageError(EdhocMessage):
         self.conn_id = conn_id
         self.suites_r = suites_r
 
+    def __repr__(self):
+        return "<%s: %s on connection ID %r%s>" % (
+                type(self).__name__,
+                self.err_msg,
+                self.conn_id,
+                " with suites %r" % self.suites_r if self.suites_r else ""
+                )
+
     def encode(self):
-        pass
+        raise NotImplementedError("Can not encode %r yet" % self)

--- a/edhoc/messages/message1.py
+++ b/edhoc/messages/message1.py
@@ -3,7 +3,7 @@ from typing import List, TYPE_CHECKING, Optional
 
 import cbor2
 
-from edhoc.exceptions import EdhocException
+from edhoc.exceptions import EdhocInvalidMessage
 from edhoc.messages.base import EdhocMessage
 
 if TYPE_CHECKING:
@@ -38,7 +38,7 @@ class MessageOne(EdhocMessage):
             selected_cipher = decoded[cls.CIPHERS][0]
             supported_ciphers = decoded[cls.CIPHERS][1:]
         else:
-            raise EdhocException("Failed to decode bytes as MessageOne")
+            raise EdhocInvalidMessage("Failed to decode bytes as MessageOne")
 
         g_x = decoded[cls.G_X]
 

--- a/edhoc/messages/message1.py
+++ b/edhoc/messages/message1.py
@@ -119,8 +119,7 @@ class MessageOne(EdhocMessage):
         output = f'<MessageOne: [{self.method_corr}, {self.selected_cipher} | {self.cipher_suites}, ' \
                  f'{EdhocMessage._truncate(self.g_x)}, {hexlify(self.conn_idi)}'
         if self.aad1 != b'':
-            output += [f'{hexlify(self.aad1)}]>']
-        else:
-            output += [']>']
+            output += f'{hexlify(self.aad1)}'
+        output += ']>'
 
         return output

--- a/edhoc/roles/initiator.py
+++ b/edhoc/roles/initiator.py
@@ -174,7 +174,7 @@ class Initiator(EdhocRole):
 
         if not self._verify_signature(signature=decoded[1]):
             self._internal_state = EdhocState.EDHOC_FAIL
-            return MessageError(err_msg='').encode()
+            return MessageError(err_msg='Signature verification failed').encode()
 
         try:
             ad_2 = decoded[2]

--- a/tests/coap_client.py
+++ b/tests/coap_client.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import pickle
 from binascii import unhexlify
+from pathlib import Path
 
 import cbor2
 from aiocoap import Context, Message
@@ -33,7 +34,7 @@ cert = unhexlify(cert)
 
 cred_id = cbor2.loads(unhexlify(b"a11822822e485b786988439ebcf2"))
 
-with open("cred_store.pickle", 'rb') as h:
+with (Path(__file__).parent / "cred_store.pickle").open('rb') as h:
     credentials_storage = pickle.load(h)
 
 

--- a/tests/coap_server.py
+++ b/tests/coap_server.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import pickle
 from binascii import unhexlify
+from pathlib import Path
 
 import aiocoap
 import aiocoap.resource as resource
@@ -36,7 +37,7 @@ cred_id = cbor2.loads(unhexlify(b"a11822822e48fc79990f2431a3f5"))
 
 
 class EdhocResponder(resource.Resource):
-    cred_store = "cred_store.pickle"
+    cred_store = Path(__file__).parent / "cred_store.pickle"
 
     def __init__(self, cred_idr, cred, auth_key):
         super().__init__()


### PR DESCRIPTION
This is based on #7, so it's actually only the last 2 commits that count, which resolve minor issues.

Creating a dedicated EdhocInvalidMessage may look like an odd choice, but a) I personally prefer fine-grained exception classes even if they're not acted on, and b) it was intermittently useful for distinguishing whether what is coming in is a message 1 or message 3 before I was made aware of the discussion in https://github.com/lake-wg/edhoc/issues/39.