### PR TITLE
Adapt to EDHOC draft -05

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Currently the protocol is still in [draft](https://datatracker.ietf.org/doc/draf
 
 The repository provides an implementation of:
   * <s>[https://datatracker.ietf.org/doc/html/draft-ietf-lake-edhoc-01](https://datatracker.ietf.org/doc/html/draft-ietf-lake-edhoc-01)</s>
-  * [https://datatracker.ietf.org/doc/html/draft-ietf-lake-edhoc-02](https://datatracker.ietf.org/doc/html/draft-ietf-lake-edhoc-02)
+  * [https://datatracker.ietf.org/doc/html/draft-ietf-lake-edhoc-05](https://datatracker.ietf.org/doc/html/draft-ietf-lake-edhoc-05)
   
 ## Installation
 

--- a/edhoc/roles/edhoc.py
+++ b/edhoc/roles/edhoc.py
@@ -138,7 +138,7 @@ class EdhocRole(metaclass=ABCMeta):
 
     def exporter(self, label: str, length: int):
         hash_func = config_cose(self.cipher_suite.hash).hash
-        return self._hkdf_expand(length, label, self._prk4x3m, self.transcript(hash_func, self._th4_input))
+        return self._hkdf_expand(length, label, self._prk4x3m, self._th4_input)
 
     @property
     @abstractmethod

--- a/edhoc/roles/initiator.py
+++ b/edhoc/roles/initiator.py
@@ -260,5 +260,5 @@ class Initiator(EdhocRole):
 
     def _decrypt(self, ciphertext: bytes) -> bytes:
         length = len(ciphertext)
-        xord = int.from_bytes(ciphertext, "big") ^ int.from_bytes(self._hkdf2(length, "K_2e", self._prk2e), "big")
+        xord = int.from_bytes(ciphertext, "big") ^ int.from_bytes(self._hkdf2(length, "KEYSTREAM_2", self._prk2e), "big")
         return xord.to_bytes((xord.bit_length() + 7) // 8, byteorder="big")

--- a/edhoc/roles/responder.py
+++ b/edhoc/roles/responder.py
@@ -104,7 +104,7 @@ class Responder(EdhocRole):
         """ Create the ciphertext_2 message part from EDHOC message 2. """
 
         length = len(self._p_2e)
-        xord = int.from_bytes(self._p_2e, "big") ^ int.from_bytes(self._hkdf2(length, "K_2e", self._prk2e), "big")
+        xord = int.from_bytes(self._p_2e, "big") ^ int.from_bytes(self._hkdf2(length, "KEYSTREAM_2", self._prk2e), "big")
         return xord.to_bytes((xord.bit_length() + 7) // 8, byteorder="big")
 
     @property


### PR DESCRIPTION
This is based on #8, so please ignore the earlier commits (which GitHub just doesn't manage to hide as "from other branch").

This is incomplete as the test suite's vectors are not adjusted -- but then again I haven't manage to run the tests yet. (`python3 -m unittest` and `python3 setup.py test` didn't run any tests, `python3 -m test` didn't terminate).