### PR TITLE
Remove CORR_UNKNOWN

### DIFF
--- a/edhoc/definitions.py
+++ b/edhoc/definitions.py
@@ -33,7 +33,6 @@ class Method(IntEnum):
 
 @unique
 class Correlation(IntEnum):
-    CORR_UNKNOWN = -1
     CORR_0 = 0
     CORR_1 = 1
     CORR_2 = 2

--- a/edhoc/messages/message1.py
+++ b/edhoc/messages/message1.py
@@ -77,9 +77,9 @@ class MessageOne(EdhocMessage):
         """
         Creates an EDHOC MessageOne object.
 
-        :param method_corr: Determines which connection identifiers that are omitted.
-        :param cipher_suites: Cipher suites chosen by the Initiator (ordered by decreasing preference).
-        :param selected_cipher: The selected cipher.
+        :param method_corr: Combination of the method parameter and correlation parameter (4 * method + correlation)
+        :param cipher_suites: Supported cipher suites (ordered by decreasing preference).
+        :param selected_cipher: The preferred cipher suite.
         :param g_x: The ephemeral public key of the Initiator.
         :param conn_idi: A variable length connection identifier.
         :param external_aad: Unprotected opaque auxiliary data (transferred together with EDHOC message 1).
@@ -95,11 +95,10 @@ class MessageOne(EdhocMessage):
         self.corr = self.method_corr % 4
         self.method = (self.method_corr - self.corr) // 4
 
-    def encode(self, corr: Correlation = Correlation.CORR_UNKNOWN) -> bytes:
+    def encode(self, corr: Correlation) -> bytes:
         """
-        Encodes the first EDHOC message.
+        Encodes the first EDHOC message as a CBOR sequence.
 
-        :raises EdhocCipherException: Invalid cipher configuration.
         :returns: EDHOC message 1 encoded as bytes.
         """
 

--- a/edhoc/roles/edhoc.py
+++ b/edhoc/roles/edhoc.py
@@ -265,7 +265,7 @@ class EdhocRole(metaclass=ABCMeta):
 
     @property
     def _th2_input(self) -> CBOR:
-        return b''.join([self.msg_1.encode(), self.data_2])
+        return b''.join([self.msg_1.encode(self.corr), self.data_2])
 
     @property
     def _th3_input(self) -> CBOR:

--- a/edhoc/roles/initiator.py
+++ b/edhoc/roles/initiator.py
@@ -169,7 +169,7 @@ class Initiator(EdhocRole):
 
         self._internal_state = EdhocState.MSG_1_SENT
 
-        return self.msg_1.encode()
+        return self.msg_1.encode(self.corr)
 
     def create_message_three(self, message_two: bytes):
 

--- a/tests/test_message1.py
+++ b/tests/test_message1.py
@@ -11,7 +11,7 @@ def test_message1_encode(test_vectors):
         conn_idi=test_vectors["I"]["conn_id"],
         external_aad=test_vectors["I"]["ad_1"])
 
-    assert msg.encode() == test_vectors["S"]["message_1"]
+    assert msg.encode(test_vectors["S"]["corr"]) == test_vectors["S"]["message_1"]
 
 
 def test_message1_decode(test_vectors):


### PR DESCRIPTION
Removes the definition of CORR_UNKNOWN and requires the correlation value to be passed to message1 encode method