### PR TITLE
Add support for P384

### DIFF
--- a/edhoc/definitions.py
+++ b/edhoc/definitions.py
@@ -4,7 +4,7 @@ from typing import Callable, Any, TypeVar, NamedTuple
 
 import cbor2
 from cose.algorithms import AESCCM1664128, Sha256, EdDSA, AESCCM16128128, Es256, A128GCM, A256GCM, Sha384, Es384
-from cose.curves import X25519, Ed25519, P256, P384
+from cose.keys.curves import X25519, Ed25519, P256, P384
 
 from edhoc.exceptions import EdhocException
 

--- a/edhoc/messages/message1.py
+++ b/edhoc/messages/message1.py
@@ -12,11 +12,12 @@ if TYPE_CHECKING:
 
 
 class MessageOne(EdhocMessage):
-    METHOD_CORR = 0
-    CIPHERS = 1
-    G_X = 2
-    CONN_ID = 3
-    AAD1 = 4
+    C_1 = 0
+    METHOD_CORR = 1
+    CIPHERS = 2
+    G_X = 3
+    CONN_ID = 4
+    AAD1 = 5
 
     @classmethod
     def decode(cls, received: bytes) -> 'MessageOne':
@@ -32,6 +33,9 @@ class MessageOne(EdhocMessage):
         decoded = super().decode(received)
 
         method_corr = decoded[cls.METHOD_CORR]
+
+        if decoded[cls.C_1] is not None:
+            raise EdhocInvalidMessage("No leading nil")
 
         if isinstance(decoded[cls.CIPHERS], int):
             selected_cipher = decoded[cls.CIPHERS]
@@ -109,7 +113,7 @@ class MessageOne(EdhocMessage):
         else:
             raise ValueError('Cipher suite list must contain at least 1 item.')
 
-        msg = [self.method_corr, suites, self.g_x, self.encode_bstr_id(self.conn_idi)]
+        msg = [None, self.method_corr, suites, self.g_x, self.encode_bstr_id(self.conn_idi)]
 
         if self.aad1 != b'':
             msg.append(cbor2.dumps(self.aad1))

--- a/edhoc/roles/edhoc.py
+++ b/edhoc/roles/edhoc.py
@@ -5,8 +5,8 @@ from typing import List, Dict, Optional, Callable, Union, Any, Type, TYPE_CHECKI
 
 import cbor2
 from cose import headers
-from cose.curves import X25519, X448, P256
-from cose.exceptions import CoseIllegalCurve
+from cose.keys.curves import X25519, X448, P256
+from cose.exceptions import CoseUnsupportedCurve
 from cose.headers import CoseHeaderAttribute
 from cose.keys import OKPKey, EC2Key, SymmetricKey
 from cose.keys.keyops import EncryptOp
@@ -142,7 +142,7 @@ class EdhocRole(metaclass=ABCMeta):
             x = x.public_key()
             secret = d.exchange(ec.ECDH(), x)
         else:
-            raise CoseIllegalCurve(f"{public_key.crv} is unsupported")
+            raise CoseUnsupportedCurve(f"{public_key.crv} is unsupported")
 
         return secret
 

--- a/edhoc/roles/edhoc.py
+++ b/edhoc/roles/edhoc.py
@@ -5,7 +5,7 @@ from typing import List, Dict, Optional, Callable, Union, Any, Type, TYPE_CHECKI
 
 import cbor2
 from cose import headers
-from cose.keys.curves import X25519, X448, P256
+from cose.keys.curves import X25519, X448, P256, P384
 from cose.exceptions import CoseUnsupportedCurve
 from cose.headers import CoseHeaderAttribute
 from cose.keys import OKPKey, EC2Key, SymmetricKey
@@ -15,7 +15,6 @@ from cose.messages import Sign1Message, Enc0Message
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, hmac, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey, X25519PublicKey
 from cryptography.hazmat.primitives.asymmetric.x448 import X448PublicKey, X448PrivateKey
 from cryptography.hazmat.primitives.kdf.hkdf import HKDFExpand
@@ -133,12 +132,13 @@ class EdhocRole(metaclass=ABCMeta):
 
             x = X448PublicKey.from_public_bytes(public_key.x)
             secret = d.exchange(x)
-        elif public_key.crv == P256:
-            d = ec.derive_private_key(int(hexlify(private_key.d), 16), SECP256R1(), default_backend())
+        elif public_key.crv in (P256, P384):
+            curve_obj = public_key.crv.curve_obj()
+            d = ec.derive_private_key(int(hexlify(private_key.d), 16), curve_obj, default_backend())
 
             x = ec.EllipticCurvePublicNumbers(int(hexlify(public_key.x), 16),
                                               int(hexlify(public_key.y), 16),
-                                              SECP256R1())
+                                              curve_obj)
             x = x.public_key()
             secret = d.exchange(ec.ECDH(), x)
         else:

--- a/edhoc/roles/initiator.py
+++ b/edhoc/roles/initiator.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Callable, Union, Tuple, TYPE_CHECKING, Type
 import cbor2
 from asn1crypto.x509 import Certificate
 from cose import headers
-from cose.curves import X448, X25519
+from cose.keys.curves import X448, X25519
 from cose.headers import KID
 from cose.keys import OKPKey, EC2Key
 from cose.keys.keyops import EncryptOp

--- a/edhoc/roles/responder.py
+++ b/edhoc/roles/responder.py
@@ -5,7 +5,7 @@ from typing import List, Callable, Optional, Union, Tuple, TYPE_CHECKING, Type
 import cbor2
 from asn1crypto.x509 import Certificate
 from cose import headers
-from cose.curves import X25519, X448
+from cose.keys.curves import X25519, X448
 from cose.headers import KID
 from cose.keys import OKPKey, EC2Key
 from cose.keys.keyops import DecryptOp

--- a/edhoc/roles/responder.py
+++ b/edhoc/roles/responder.py
@@ -220,7 +220,7 @@ class Responder(EdhocRole):
         self.cred_idi = decoded[0]
 
         if not self._verify_signature_or_mac3(signature_or_mac3=decoded[1]):
-            return MessageError(err_msg='').encode()
+            return MessageError(err_msg='Signature verification failed').encode()
 
         try:
             ad_3 = decoded[2]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cbor2>=5.2.0
 cryptography>=3.2.1
-cose>=0.9dev5
+cose>=0.9dev7
 aiocoap
 asn1crypto
 


### PR DESCRIPTION
This adds to #22 by fixing support for ciphersuite 5 (which I added earlier, but could not test in full; now it has at least exchanged with my own implementation).

The same generalization as done here can not be applied to the X25519/X448 paragraphs above, as they only provide their respective PrivateKey classes in curve_obj from pycose; it may make sense to split curve_obj up into the respective underlying classes -- not sure if an EC2 key's curve_obj interface is even compatible with OPK's, so maybe they could be named differently at all or just a property for the public thing be added.