### PR TITLE
requirements.txt: fix cose version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cbor2>=5.2.0
 cryptography>=3.2.1
-cose>=0.9dev5
+cose==0.9dev5
 aiocoap
 asn1crypto
 


### PR DESCRIPTION
Patch alternative to https://github.com/openwsn-berkeley/py-edhoc/pull/25 so that build succeed until issues with latest py-cose can be resolved.