### PR TITLE
edhoc/messages/base: fix decode_bstr_id for non int

### DIFF
--- a/edhoc/messages/base.py
+++ b/edhoc/messages/base.py
@@ -38,8 +38,11 @@ class EdhocMessage(metaclass=ABCMeta):
             return conn_id
 
     @staticmethod
-    def decode_bstr_id(conn_id: int) -> bytes:
-        return int(conn_id + 24).to_bytes(1, byteorder="big")
+    def decode_bstr_id(conn_id: Union[int, bytes]) -> bytes:
+        if isinstance(conn_id, int):
+            return int(conn_id + 24).to_bytes(1, byteorder="big")
+        else:
+            return conn_id
 
     @classmethod
     def _truncate(cls, payload: bytes):


### PR DESCRIPTION
Current code would error if a byte string is used as conn_id, this fixse it.