### PR TITLE
fix: instantiate COSE key object when key comes from certificate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 dist/
 docs/build/
 build/
+*.swp

--- a/edhoc/roles/initiator.py
+++ b/edhoc/roles/initiator.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Callable, Union, Tuple, TYPE_CHECKING, Type
 import cbor2
 from asn1crypto.x509 import Certificate
 from cose import headers
-from cose.curves import X448, X25519, Ed25519
+from cose.curves import X448, X25519
 from cose.headers import KID
 from cose.keys import OKPKey, EC2Key
 from cose.keys.keyops import EncryptOp
@@ -209,9 +209,9 @@ class Initiator(EdhocRole):
                 phdr=self.cred_idr,
                 uhdr={headers.Algorithm: self.cipher_suite.sign_alg},
                 payload=mac_2,
+                key=self.remote_authkey,
                 external_aad=external_aad)
             # FIXME peeking into internals (probably best resolved at pycose level)
-            cose_sign.key = self.remote_authkey
             cose_sign._signature = signature_or_mac2
             return cose_sign.verify_signature()
         else:

--- a/edhoc/roles/initiator.py
+++ b/edhoc/roles/initiator.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Callable, Union, Tuple, TYPE_CHECKING, Type
 import cbor2
 from asn1crypto.x509 import Certificate
 from cose import headers
-from cose.curves import X448, X25519
+from cose.curves import X448, X25519, Ed25519
 from cose.headers import KID
 from cose.keys import OKPKey, EC2Key
 from cose.keys.keyops import EncryptOp
@@ -211,7 +211,8 @@ class Initiator(EdhocRole):
                 payload=mac_2,
                 external_aad=external_aad)
             # FIXME peeking into internals (probably best resolved at pycose level)
-            cose_sign.key = self.remote_authkey
+            # FIXME should handle different key types
+            cose_sign.key = OKPKey(crv=Ed25519, x=self.remote_authkey)
             cose_sign._signature = signature_or_mac2
             return cose_sign.verify_signature()
         else:

--- a/edhoc/roles/initiator.py
+++ b/edhoc/roles/initiator.py
@@ -211,8 +211,7 @@ class Initiator(EdhocRole):
                 payload=mac_2,
                 external_aad=external_aad)
             # FIXME peeking into internals (probably best resolved at pycose level)
-            # FIXME should handle different key types
-            cose_sign.key = OKPKey(crv=Ed25519, x=self.remote_authkey)
+            cose_sign.key = self.remote_authkey
             cose_sign._signature = signature_or_mac2
             return cose_sign.verify_signature()
         else:

--- a/edhoc/roles/responder.py
+++ b/edhoc/roles/responder.py
@@ -247,8 +247,7 @@ class Responder(EdhocRole):
                 payload=mac_3,
                 external_aad=external_aad)
             # FIXME peeking into internals (probably best resolved at pycose level)
-            # FIXME should handle different key types
-            cose_sign.key = OKPKey(crv=Ed25519, x=self.remote_authkey)
+            cose_sign.key = self.remote_authkey
             cose_sign._signature = signature_or_mac3
             return cose_sign.verify_signature()
         else:

--- a/edhoc/roles/responder.py
+++ b/edhoc/roles/responder.py
@@ -5,7 +5,7 @@ from typing import List, Callable, Optional, Union, Tuple, TYPE_CHECKING, Type
 import cbor2
 from asn1crypto.x509 import Certificate
 from cose import headers
-from cose.curves import X25519, X448
+from cose.curves import X25519, X448, Ed25519
 from cose.headers import KID
 from cose.keys import OKPKey, EC2Key
 from cose.keys.keyops import DecryptOp
@@ -247,7 +247,8 @@ class Responder(EdhocRole):
                 payload=mac_3,
                 external_aad=external_aad)
             # FIXME peeking into internals (probably best resolved at pycose level)
-            cose_sign.key = self.remote_authkey
+            # FIXME should handle different key types
+            cose_sign.key = OKPKey(crv=Ed25519, x=self.remote_authkey)
             cose_sign._signature = signature_or_mac3
             return cose_sign.verify_signature()
         else:

--- a/edhoc/roles/responder.py
+++ b/edhoc/roles/responder.py
@@ -5,7 +5,7 @@ from typing import List, Callable, Optional, Union, Tuple, TYPE_CHECKING, Type
 import cbor2
 from asn1crypto.x509 import Certificate
 from cose import headers
-from cose.curves import X25519, X448, Ed25519
+from cose.curves import X25519, X448
 from cose.headers import KID
 from cose.keys import OKPKey, EC2Key
 from cose.keys.keyops import DecryptOp
@@ -245,9 +245,9 @@ class Responder(EdhocRole):
                 phdr=self.cred_idi,
                 uhdr={headers.Algorithm: self.cipher_suite.sign_alg},
                 payload=mac_3,
+                key=self.remote_authkey,
                 external_aad=external_aad)
             # FIXME peeking into internals (probably best resolved at pycose level)
-            cose_sign.key = self.remote_authkey
             cose_sign._signature = signature_or_mac3
             return cose_sign.verify_signature()
         else:


### PR DESCRIPTION
When running the programs in the `scripts` folder, I got `cose.exceptions.CoseException: Invalid COSE key`.

It happened because, when extracted from a certificate, auth_key is a raw public key, whereas cose_sign.key expects a COSE key object.