### PR TITLE
setup: Provide links to project repository

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,10 @@ setup(
     keywords=['EDHOC', 'Internet of Things', 'CBOR', 'object security', 'COSE', 'OSCORE', 'cryptography'],
     author='Timothy Claeys',
     author_email='timothy.claeys@gmail.com',
+    url='https://github.com/openwsn-berkeley/py-edhoc',
+    project_urls={
+        'Issue tracker': 'https://github.com/openwsn-berkeley/py-edhoc/issues',
+    },
     license='BSD-3',
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
There is currently no link from the pypi page to this repo; with the next release and this PR merged, that can be fixed.

(Once we start building documentation, eg. on readthedocs, we can add that link too.)